### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/src/autogen-environment/environment.yml
+++ b/src/autogen-environment/environment.yml
@@ -16,7 +16,7 @@ dependencies:
     - pandas
     - pillow
     - prompt_toolkit
-    - pyautogen[teachable,lmm,retrievechat,mathchat,blendsearch]
+    - ag2[teachable,lmm,retrievechat,mathchat,blendsearch]
     - pydoc-markdown
     - pytest
     - requests

--- a/src/memgpt-environment/environment.yml
+++ b/src/memgpt-environment/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip
   - pip :
     - pymemgpt[local,postgres]
-    - pyautogen[teachable]
+    - ag2[teachable]
     - llama-index-core
     - llama-index-readers-file
     - llama-index-llms-ollama


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using AG2! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
